### PR TITLE
Fix CNP logic to recognise 70 as valid county code

### DIFF
--- a/cnp.js
+++ b/cnp.js
@@ -68,7 +68,7 @@ const validCNP = (cnp) => {
         return false;
       }
   }
-  if (contyCode < 0 || (contyCode > 46 && contyCode < 51) || contyCode > 52) {
+  if (contyCode !== 70 && (contyCode < 0 || (contyCode > 46 && contyCode < 51) || contyCode > 52)) {
     return false;
   }
   let controlSum = cnp.reduce((sum, cnp, i) => {


### PR DESCRIPTION
In rare cases, a CNP can be issued with a county code of 70. 70 is a valid county code that means "universal county".